### PR TITLE
[fix] Update webhook tests and refactor compilation handling

### DIFF
--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -1,27 +1,17 @@
-from fastapi import Request
-from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
-from src.compilation import app, run_syntax_check, webhook_handler
-import asyncio
+from unittest.mock import patch, MagicMock
+from src.app import app
+from src.compilation import handle_compilation, run_syntax_check
 
 client = TestClient(app)
 
-async def test_webhook_invalid_payload():
-    request = Request(scope={"type": "http"}, receive=lambda: None)
-    request._json = {}  # Mocking request.json()
-    response = await webhook_handler(request)
-    assert response.status_code == 400
-    assert "Invalid payload" in response.detail
-
-async def test_webhook_valid_branch():
+async def test_handle_compilation_valid_branch():
     with patch("src.compilation.git.Repo") as mock_repo:
         mock_repo.return_value.git.checkout = MagicMock()
         mock_repo.return_value.git.pull = MagicMock()
         
-        request = Request(scope={"type": "http"}, receive=lambda: None)
-        request._json = {"ref": "refs/heads/test-branch"}  # Mocking request.json()
-        response = await webhook_handler(request)
-        assert response["message"].startswith("Compilation (syntax check) completed")
+        result = await handle_compilation("test-branch")
+        assert result["message"].startswith("Compilation (syntax check) completed")
 
 def test_run_syntax_check_valid():
     with patch("subprocess.run") as mock_run:
@@ -34,3 +24,25 @@ def test_run_syntax_check_invalid():
         mock_run.return_value.stdout = "test.py:1:1: E999 SyntaxError: invalid syntax"
         result = run_syntax_check("test_directory")
         assert "E999 SyntaxError" in result
+
+def test_webhook_endpoint():
+    with patch("src.app.handle_compilation") as mock_handle:
+        mock_handle.return_value = {
+            "message": "Compilation completed",
+            "output": "No syntax errors found."
+        }
+        
+        response = client.post("/webhook", json={
+            "ref": "refs/heads/test-branch",
+            "repository": {"full_name": "test/repo"},
+            "commits": [],
+            "head_commit": {"id": "123abc"}
+        })
+        
+        assert response.status_code == 200
+        assert response.json()["branch"] == "test-branch"
+        assert response.json()["status"] == "completed"
+
+def test_webhook_invalid_payload():
+    response = client.post("/webhook", json={})
+    assert response.status_code == 422  # FastAPI validation error

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -1,10 +1,12 @@
 from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
+import pytest
 from src.app import app
 from src.compilation import handle_compilation, run_syntax_check
 
 client = TestClient(app)
 
+@pytest.mark.asyncio
 async def test_handle_compilation_valid_branch():
     with patch("src.compilation.git.Repo") as mock_repo:
         mock_repo.return_value.git.checkout = MagicMock()


### PR DESCRIPTION
Discovered that the tests were not updated when changing the structure so this pr fixes it (previous pr: #42)

Fixes #37, fixes #43